### PR TITLE
Add resume screening pipeline and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# Machine-Learning-Powered-Resume-Screener
+# Machine Learning Powered Resume Screener
+
+This project provides a light-weight pipeline for screening resume PDFs against a job description. It includes:
+
+- PDF text extraction utilities powered by `pdfminer.six`.
+- A simple NLP similarity model based on TF-IDF and cosine similarity.
+- A command line interface to rank resume PDFs and export the results.
+- Unit tests covering the matching logic.
+
+## Project structure
+
+```
+.
+├── cli.py                     # Command line entry point
+├── resume_screener/
+│   ├── __init__.py
+│   ├── matching.py            # TF-IDF implementation and similarity scoring
+│   ├── pdf_extractor.py       # Helpers to extract text from PDFs
+│   ├── pipeline.py            # High-level orchestration helpers
+│   └── preprocessing.py       # Tokenisation and text normalisation tools
+└── resume_screener/tests/
+    └── test_matching.py       # Unit tests
+```
+
+## Installation
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+1. Save your job description to a plain text file, for example `job.txt`.
+2. Place all candidate resumes as PDF files in a single directory, for example `resumes/`.
+3. Run the CLI to generate the ranking:
+
+```bash
+python cli.py job.txt resumes/ --top-k 5 --output results.json
+```
+
+The command prints the matches in descending order of similarity and optionally saves them to JSON or CSV based on the output file extension.
+
+## Running tests
+
+```bash
+python -m pytest
+```

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,89 @@
+"""Command line interface for the resume screening pipeline."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Iterable
+
+from resume_screener import matching, pipeline
+
+
+def _parse_arguments(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Match resume PDFs against a job description using NLP.",
+    )
+    parser.add_argument(
+        "job_description",
+        type=Path,
+        help="Path to a plain text file containing the job description.",
+    )
+    parser.add_argument(
+        "resume_dir",
+        type=Path,
+        help="Directory containing PDF resumes to screen.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=None,
+        help="Only return the top K matches.",
+    )
+    parser.add_argument(
+        "--min-score",
+        type=float,
+        default=0.0,
+        help="Ignore resumes with a similarity score below this threshold.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to save the results as JSON or CSV (based on extension).",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def _serialise_results(matches: Iterable[matching.ResumeMatch], destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    summary = pipeline.summarise_matches(matches)
+
+    if destination.suffix.lower() == ".json":
+        destination.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    elif destination.suffix.lower() == ".csv":
+        with destination.open("w", encoding="utf-8", newline="") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=["resume_id", "score", "highlights"])
+            writer.writeheader()
+            for row in summary:
+                writer.writerow(row)
+    else:
+        raise ValueError(
+            "Unsupported output format. Use a .json or .csv file extension."
+        )
+
+
+def main(argv: Iterable[str] | None = None) -> list[matching.ResumeMatch]:
+    args = _parse_arguments(argv)
+
+    job_description_text = pipeline.load_job_description(args.job_description)
+    resume_texts = pipeline.load_resume_texts_from_directory(args.resume_dir)
+
+    matches = pipeline.screen_resumes(
+        job_description_text,
+        resume_texts,
+        top_k=args.top_k,
+        min_score=args.min_score,
+    )
+
+    if args.output:
+        _serialise_results(matches, args.output)
+
+    for match in matches:
+        highlight_text = f" (keywords: {', '.join(match.highlights)})" if match.highlights else ""
+        print(f"{match.resume_id}: {match.score:.3f}{highlight_text}")
+
+    return matches
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pdfminer.six>=20221105

--- a/resume_screener/__init__.py
+++ b/resume_screener/__init__.py
@@ -1,0 +1,11 @@
+"""Machine learning powered resume screening utilities."""
+from .matching import ResumeMatch, score_resumes
+from .pipeline import load_job_description, load_resume_texts_from_directory, screen_resumes
+
+__all__ = [
+    "ResumeMatch",
+    "score_resumes",
+    "load_job_description",
+    "load_resume_texts_from_directory",
+    "screen_resumes",
+]

--- a/resume_screener/matching.py
+++ b/resume_screener/matching.py
@@ -1,0 +1,121 @@
+"""Core resume matching logic using a light-weight TF-IDF implementation."""
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+from . import preprocessing
+
+
+@dataclass(frozen=True)
+class ResumeMatch:
+    """Represents the similarity between a resume and a job description."""
+
+    resume_id: str
+    score: float
+    highlights: Tuple[str, ...]
+
+
+def _term_frequencies(tokens: Sequence[str]) -> Dict[str, float]:
+    counts = Counter(tokens)
+    total = float(sum(counts.values())) or 1.0
+    return {term: freq / total for term, freq in counts.items()}
+
+
+def _inverse_document_frequencies(documents: Iterable[Sequence[str]]) -> Dict[str, float]:
+    document_frequency: Dict[str, int] = defaultdict(int)
+    num_documents = 0
+    for tokens in documents:
+        num_documents += 1
+        for term in set(tokens):
+            document_frequency[term] += 1
+
+    if num_documents == 0:
+        return {}
+
+    idf: Dict[str, float] = {}
+    for term, df in document_frequency.items():
+        idf[term] = math.log((1 + num_documents) / (1 + df)) + 1.0
+    return idf
+
+
+def _tfidf_vector(tokens: Sequence[str], idf: Dict[str, float]) -> Dict[str, float]:
+    tf = _term_frequencies(tokens)
+    return {term: tf_val * idf.get(term, 0.0) for term, tf_val in tf.items()}
+
+
+def _cosine_similarity(vec_a: Dict[str, float], vec_b: Dict[str, float]) -> float:
+    if not vec_a or not vec_b:
+        return 0.0
+
+    common_terms = set(vec_a).intersection(vec_b)
+    numerator = sum(vec_a[term] * vec_b[term] for term in common_terms)
+    norm_a = math.sqrt(sum(value * value for value in vec_a.values()))
+    norm_b = math.sqrt(sum(value * value for value in vec_b.values()))
+
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+
+    return numerator / (norm_a * norm_b)
+
+
+def score_resumes(
+    job_description: str,
+    resume_text_by_id: Dict[str, str],
+    *,
+    top_k: int | None = None,
+    min_score: float = 0.0,
+) -> List[ResumeMatch]:
+    """Rank resumes according to their similarity with a job description.
+
+    Parameters
+    ----------
+    job_description:
+        Raw text of the job specification.
+    resume_text_by_id:
+        Mapping of resume identifiers to their raw text.
+    top_k:
+        Limit the number of returned matches. ``None`` returns all matches.
+    min_score:
+        Minimum similarity score required for a resume to be returned.
+    """
+
+    if not job_description.strip():
+        raise ValueError("Job description text must not be empty.")
+
+    normalised_job = preprocessing.tokenize(job_description)
+    normalised_resumes: Dict[str, List[str]] = {
+        resume_id: preprocessing.tokenize(text)
+        for resume_id, text in resume_text_by_id.items()
+        if text.strip()
+    }
+
+    if not normalised_resumes:
+        return []
+
+    idf = _inverse_document_frequencies(
+        list(normalised_resumes.values()) + [normalised_job]
+    )
+    job_vector = _tfidf_vector(normalised_job, idf)
+
+    matches: List[ResumeMatch] = []
+    for resume_id, tokens in normalised_resumes.items():
+        resume_vector = _tfidf_vector(tokens, idf)
+        score = _cosine_similarity(job_vector, resume_vector)
+        if score < min_score:
+            continue
+
+        # Highlight keywords that have high tf-idf values in the resume and appear in the job description
+        shared_terms = [term for term in tokens if term in job_vector]
+        unique_shared = list(dict.fromkeys(shared_terms))
+        highlights = tuple(unique_shared[:5])
+        matches.append(ResumeMatch(resume_id=resume_id, score=score, highlights=highlights))
+
+    matches.sort(key=lambda match: match.score, reverse=True)
+
+    if top_k is not None:
+        matches = matches[:top_k]
+
+    return matches

--- a/resume_screener/pdf_extractor.py
+++ b/resume_screener/pdf_extractor.py
@@ -1,0 +1,78 @@
+"""Utilities for extracting text from resume PDF files."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Union
+
+
+class PDFExtractionError(RuntimeError):
+    """Raised when a PDF file cannot be processed."""
+
+
+def _coerce_path(path: Union[str, Path]) -> Path:
+    if isinstance(path, Path):
+        return path
+    return Path(path)
+
+
+def extract_text_from_pdf(path: Union[str, Path]) -> str:
+    """Extract raw text from a PDF file.
+
+    Parameters
+    ----------
+    path:
+        Path to the PDF file. Strings are automatically converted to
+        :class:`~pathlib.Path` objects.
+
+    Returns
+    -------
+    str
+        The extracted text.
+
+    Raises
+    ------
+    PDFExtractionError
+        If the file does not exist or cannot be parsed.
+    """
+
+    pdf_path = _coerce_path(path)
+    if not pdf_path.exists():
+        raise PDFExtractionError(f"PDF file not found: {pdf_path}")
+
+    try:
+        from pdfminer.high_level import extract_text  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error is environment specific
+        raise PDFExtractionError(
+            "Failed to import pdfminer.six. Install it with 'pip install pdfminer.six'."
+        ) from exc
+
+    try:
+        text = extract_text(str(pdf_path))
+    except Exception as exc:  # pragma: no cover - pdfminer errors difficult to trigger reliably
+        raise PDFExtractionError(f"Failed to extract text from {pdf_path}") from exc
+
+    if not text.strip():
+        raise PDFExtractionError(f"No text could be extracted from {pdf_path}")
+
+    return text
+
+
+def batch_extract_text(paths: Iterable[Union[str, Path]]) -> dict[str, str]:
+    """Extract text from multiple PDF files.
+
+    Parameters
+    ----------
+    paths:
+        Iterable of PDF file paths.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of file names to extracted text.
+    """
+
+    results: dict[str, str] = {}
+    for path in paths:
+        pdf_path = _coerce_path(path)
+        results[pdf_path.stem] = extract_text_from_pdf(pdf_path)
+    return results

--- a/resume_screener/pipeline.py
+++ b/resume_screener/pipeline.py
@@ -1,0 +1,65 @@
+"""High level orchestration helpers for the resume screening workflow."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from . import matching
+from .pdf_extractor import batch_extract_text
+
+
+def load_job_description(path: Path | str) -> str:
+    """Load a job description from a plain text file."""
+
+    job_path = Path(path)
+    if not job_path.exists():
+        raise FileNotFoundError(f"Job description file not found: {job_path}")
+    return job_path.read_text(encoding="utf-8")
+
+
+def load_resume_texts_from_directory(directory: Path | str) -> Dict[str, str]:
+    """Read all PDF files in a directory and extract their text."""
+
+    dir_path = Path(directory)
+    if not dir_path.exists():
+        raise FileNotFoundError(f"Resume directory not found: {dir_path}")
+
+    pdf_files = sorted(dir_path.glob("*.pdf"))
+    if not pdf_files:
+        raise FileNotFoundError(
+            f"No PDF files were found in resume directory: {dir_path}"
+        )
+
+    return batch_extract_text(pdf_files)
+
+
+def screen_resumes(
+    job_description_text: str,
+    resume_text_by_id: Dict[str, str],
+    *,
+    top_k: int | None = None,
+    min_score: float = 0.0,
+) -> List[matching.ResumeMatch]:
+    """Score resumes against a job description and return ranked matches."""
+
+    return matching.score_resumes(
+        job_description=job_description_text,
+        resume_text_by_id=resume_text_by_id,
+        top_k=top_k,
+        min_score=min_score,
+    )
+
+
+def summarise_matches(matches: Iterable[matching.ResumeMatch]) -> List[dict[str, str]]:
+    """Convert :class:`ResumeMatch` objects into serialisable dictionaries."""
+
+    summary: List[dict[str, str]] = []
+    for match in matches:
+        summary.append(
+            {
+                "resume_id": match.resume_id,
+                "score": f"{match.score:.3f}",
+                "highlights": ", ".join(match.highlights),
+            }
+        )
+    return summary

--- a/resume_screener/preprocessing.py
+++ b/resume_screener/preprocessing.py
@@ -1,0 +1,55 @@
+"""Text normalisation and tokenisation helpers."""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+# A lightweight set of stop words that helps focus on meaningful tokens.
+STOP_WORDS: set[str] = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "to",
+    "with",
+}
+
+TOKEN_PATTERN = re.compile(r"[a-zA-Z0-9]+")
+
+
+def tokenize(text: str) -> List[str]:
+    """Tokenise text into a list of alphanumeric words.
+
+    The output is lower-cased and filters out a compact list of stop words to
+    emphasise keywords contained in resumes and job descriptions.
+    """
+
+    raw_tokens = TOKEN_PATTERN.findall(text.lower())
+    return [token for token in raw_tokens if token not in STOP_WORDS]
+
+
+def normalise(text: str) -> str:
+    """Collapse whitespace and lower-case the text."""
+
+    tokens = tokenize(text)
+    return " ".join(tokens)
+
+
+def flatten_documents(documents: Iterable[str]) -> str:
+    """Concatenate multiple documents into a single text blob."""
+
+    return " \n".join(documents)

--- a/resume_screener/tests/test_matching.py
+++ b/resume_screener/tests/test_matching.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from resume_screener import matching
+
+
+def test_score_resumes_ranks_by_similarity():
+    job_description = """
+    Looking for a data scientist with python, machine learning and NLP experience.
+    """
+    resume_texts = {
+        "alice": "Experienced data scientist skilled in Python, NLP, and TensorFlow.",
+        "bob": "Front-end developer with React and CSS expertise.",
+        "carol": "Machine learning engineer proficient in Python and data analysis.",
+    }
+
+    matches = matching.score_resumes(job_description, resume_texts)
+    assert [match.resume_id for match in matches] == ["alice", "carol", "bob"]
+    assert matches[0].score >= matches[1].score >= matches[2].score
+
+
+def test_score_resumes_filters_by_threshold():
+    job_description = "Cloud engineer Kubernetes"
+    resume_texts = {
+        "alice": "Kubernetes administrator and DevOps specialist.",
+        "bob": "Graphic designer experienced with Adobe tools.",
+    }
+
+    matches = matching.score_resumes(job_description, resume_texts, min_score=0.1)
+    assert [match.resume_id for match in matches] == ["alice"]


### PR DESCRIPTION
## Summary
- implement a lightweight TF-IDF-based matcher with keyword highlights for ranking resumes
- add PDF extraction and orchestration helpers plus a CLI to run the screening workflow
- document the project structure and provide requirements and pytest coverage for the core logic

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d63bed6d7483259e0a312bcf714548