### PR TITLE
Allow optional job description upload in Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -131,26 +131,21 @@ def main() -> None:
 
     st.subheader("Job description")
     job_description_file = st.file_uploader(
-
-        "Upload a job description file",
+        "Upload a job description file (optional)",
         type=["txt", "pdf", "docx"],
-
-        "Upload a job description text file",
-        type=["txt"],
-
-        help="Optional: you can paste text directly into the editor below instead.",
+        help=(
+            "Upload a job description document or leave this blank and type the "
+            "details manually in the editor below."
+        ),
     )
 
     initial_job_description = ""
     if job_description_file is not None:
-
         try:
             initial_job_description = _load_job_description(job_description_file)
         except (ValueError, PDFExtractionError) as exc:
             st.error(str(exc))
             return
-
-        initial_job_description = job_description_file.read().decode("utf-8", errors="ignore")
 
 
     job_description_text = st.text_area(


### PR DESCRIPTION
## Summary
- clarify that uploading the job description file is optional and remove the redundant uploader arguments
- keep the uploaded job description text in the editor without requiring a manual re-upload

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d666637034832585c37c1cf5ada600