### PR TITLE
Support explicit job description input mode and smarter highlights

### DIFF
--- a/resume_screener/matching.py
+++ b/resume_screener/matching.py
@@ -107,10 +107,18 @@ def score_resumes(
         if score < min_score:
             continue
 
-        # Highlight keywords that have high tf-idf values in the resume and appear in the job description
-        shared_terms = [term for term in tokens if term in job_vector]
-        unique_shared = list(dict.fromkeys(shared_terms))
-        highlights = tuple(unique_shared[:5])
+        # Highlight keywords that carry the most weight for both the resume and job description.
+        candidate_terms = []
+        for term in set(tokens):
+            if term not in job_vector:
+                continue
+            weight = resume_vector.get(term, 0.0) * job_vector.get(term, 0.0)
+            if weight <= 0.0:
+                continue
+            candidate_terms.append((term, weight))
+
+        candidate_terms.sort(key=lambda item: item[1], reverse=True)
+        highlights = tuple(term for term, _ in candidate_terms[:5])
         matches.append(ResumeMatch(resume_id=resume_id, score=score, highlights=highlights))
 
     matches.sort(key=lambda match: match.score, reverse=True)


### PR DESCRIPTION
## Summary
- add an explicit choice between using an uploaded job description document or typing it manually so the editor is never autofilled
- validate the selected input mode before screening resumes to avoid empty descriptions
- score highlight keywords by combined TF-IDF weight so the surfaced snippets better reflect the role requirements

## Testing
- python -m compileall streamlit_app.py resume_screener

------
https://chatgpt.com/codex/tasks/task_e_68d666637034832585c37c1cf5ada600