### PR TITLE
Enhance Streamlit resume screener with insights and keyword controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,14 @@ The command prints the matches in descending order of similarity and optionally 
 
 ## Interactive Streamlit app
 
-To explore the resume screener in the browser, run the Streamlit application:
+The Streamlit interface provides:
+
+- Uploading of job descriptions (TXT, PDF, DOCX) with live editing.
+- Configurable "must-have" keyword filters to flag or hide unsuitable resumes.
+- Keyword intelligence dashboards that surface the most important job skills and their coverage across candidates.
+- Detailed per-candidate insights showing matched skills, missing keywords, and download options for ranked results.
+
+Run the application locally with:
 
 ```bash
 streamlit run streamlit_app.py

--- a/resume_screener/__init__.py
+++ b/resume_screener/__init__.py
@@ -1,9 +1,22 @@
 """Machine learning powered resume screening utilities."""
-from .matching import ResumeMatch, score_resumes
+from .matching import (
+    CorpusSnapshot,
+    KeywordInsight,
+    ResumeMatch,
+    extract_keyword_insights,
+    missing_keywords_for_resume,
+    prepare_corpus,
+    score_resumes,
+)
 from .pipeline import load_job_description, load_resume_texts_from_directory, screen_resumes
 
 __all__ = [
+    "CorpusSnapshot",
+    "KeywordInsight",
     "ResumeMatch",
+    "extract_keyword_insights",
+    "missing_keywords_for_resume",
+    "prepare_corpus",
     "score_resumes",
     "load_job_description",
     "load_resume_texts_from_directory",

--- a/resume_screener/tests/conftest.py
+++ b/resume_screener/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Ensure the package root is on the import path for tests."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- expose corpus preparation utilities and keyword insight helpers for downstream UIs
- expand the Streamlit app with must-have keyword filtering, analytics dashboards, and detailed candidate breakdowns
- document the richer Streamlit experience and extend unit tests for the new matching helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d672c8ec8c83258b601db27e0f8f99