### PR TITLE
Switch resume matching to sentence embeddings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pdfminer.six>=20221105
 streamlit>=1.30
 python-docx>=0.8.11
+sentence-transformers>=2.2.2
 

--- a/resume_screener/matching.py
+++ b/resume_screener/matching.py
@@ -1,12 +1,18 @@
-"""Core resume matching logic using a light-weight TF-IDF implementation."""
+"""Core resume matching logic backed by sentence embeddings."""
 from __future__ import annotations
 
-import math
-from collections import Counter, defaultdict
+from collections import Counter
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Sequence, Tuple
+from functools import lru_cache
+from typing import Dict, List, Tuple, TYPE_CHECKING
+
+import numpy as np
 
 from . import preprocessing
+
+
+if TYPE_CHECKING:
+    from sentence_transformers import SentenceTransformer
 
 
 @dataclass(frozen=True)
@@ -23,9 +29,9 @@ class CorpusSnapshot:
     """Normalised view of the job description and resumes used for scoring."""
 
     job_tokens: Tuple[str, ...]
-    job_weights: Dict[str, float]
+    job_embedding: np.ndarray
     resume_tokens: Dict[str, Tuple[str, ...]]
-    resume_weights: Dict[str, Dict[str, float]]
+    resume_embeddings: Dict[str, np.ndarray]
 
 
 @dataclass(frozen=True)
@@ -38,77 +44,90 @@ class KeywordInsight:
     coverage_ratio: float
 
 
-def _term_frequencies(tokens: Sequence[str]) -> Dict[str, float]:
-    counts = Counter(tokens)
-    total = float(sum(counts.values())) or 1.0
-    return {term: freq / total for term, freq in counts.items()}
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 
 
-def _inverse_document_frequencies(documents: Iterable[Sequence[str]]) -> Dict[str, float]:
-    document_frequency: Dict[str, int] = defaultdict(int)
-    num_documents = 0
-    for tokens in documents:
-        num_documents += 1
-        for term in set(tokens):
-            document_frequency[term] += 1
+@lru_cache(maxsize=2)
+def _load_sentence_transformer(model_name: str = DEFAULT_EMBEDDING_MODEL) -> "SentenceTransformer":
+    """Load and cache the embedding model to avoid repeated downloads."""
 
-    if num_documents == 0:
-        return {}
+    from sentence_transformers import SentenceTransformer
 
-    idf: Dict[str, float] = {}
-    for term, df in document_frequency.items():
-        idf[term] = math.log((1 + num_documents) / (1 + df)) + 1.0
-    return idf
+    return SentenceTransformer(model_name)
 
 
-def _tfidf_vector(tokens: Sequence[str], idf: Dict[str, float]) -> Dict[str, float]:
-    tf = _term_frequencies(tokens)
-    return {term: tf_val * idf.get(term, 0.0) for term, tf_val in tf.items()}
+def build_sentence_embeddings(
+    job_description: str,
+    resume_text_by_id: Dict[str, str],
+    *,
+    model_name: str = DEFAULT_EMBEDDING_MODEL,
+) -> Tuple[np.ndarray, Dict[str, np.ndarray]]:
+    """Return dense embeddings for the job description and resumes."""
+
+    model = _load_sentence_transformer(model_name)
+
+    ordered_resume_ids = list(resume_text_by_id)
+    texts_to_encode = [job_description] + [resume_text_by_id[resume_id] for resume_id in ordered_resume_ids]
+
+    embeddings = model.encode(
+        texts_to_encode,
+        convert_to_numpy=True,
+        normalize_embeddings=True,
+    )
+
+    job_embedding = embeddings[0]
+    resume_embeddings = {
+        resume_id: embeddings[index + 1]
+        for index, resume_id in enumerate(ordered_resume_ids)
+    }
+    return job_embedding, resume_embeddings
 
 
-def _cosine_similarity(vec_a: Dict[str, float], vec_b: Dict[str, float]) -> float:
-    if not vec_a or not vec_b:
+def _cosine_similarity_dense(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    if vec_a.size == 0 or vec_b.size == 0:
         return 0.0
 
-    common_terms = set(vec_a).intersection(vec_b)
-    numerator = sum(vec_a[term] * vec_b[term] for term in common_terms)
-    norm_a = math.sqrt(sum(value * value for value in vec_a.values()))
-    norm_b = math.sqrt(sum(value * value for value in vec_b.values()))
-
-    if norm_a == 0.0 or norm_b == 0.0:
+    norm_product = float(np.linalg.norm(vec_a) * np.linalg.norm(vec_b))
+    if norm_product == 0.0:
         return 0.0
 
-    return numerator / (norm_a * norm_b)
+    return float(np.dot(vec_a, vec_b) / norm_product)
 
 
 def prepare_corpus(
     job_description: str, resume_text_by_id: Dict[str, str]
 ) -> CorpusSnapshot:
-    """Create TF-IDF representations used to compare resumes."""
+    """Create normalised tokens and sentence embeddings for scoring."""
 
     if not job_description.strip():
         raise ValueError("Job description text must not be empty.")
 
     job_tokens = tuple(preprocessing.tokenize(job_description))
-    resume_tokens: Dict[str, Tuple[str, ...]] = {
-        resume_id: tuple(preprocessing.tokenize(text))
-        for resume_id, text in resume_text_by_id.items()
-        if text.strip()
-    }
+    resume_tokens: Dict[str, Tuple[str, ...]] = {}
+    filtered_resume_texts: Dict[str, str] = {}
+    for resume_id, text in resume_text_by_id.items():
+        if not text.strip():
+            continue
+        tokens = tuple(preprocessing.tokenize(text))
+        if not tokens:
+            continue
+        resume_tokens[resume_id] = tokens
+        filtered_resume_texts[resume_id] = text
 
-    documents: List[Sequence[str]] = list(resume_tokens.values()) + [job_tokens]
-    idf = _inverse_document_frequencies(documents)
-    job_weights = _tfidf_vector(job_tokens, idf)
-    resume_weights = {
-        resume_id: _tfidf_vector(tokens, idf)
-        for resume_id, tokens in resume_tokens.items()
-    }
+    if filtered_resume_texts:
+        job_embedding, resume_embeddings = build_sentence_embeddings(
+            job_description,
+            filtered_resume_texts,
+        )
+    else:
+        job_embedding = np.zeros(1, dtype=float)
+        resume_embeddings = {}
 
     return CorpusSnapshot(
         job_tokens=job_tokens,
-        job_weights=job_weights,
+        job_embedding=job_embedding,
         resume_tokens=resume_tokens,
-        resume_weights=resume_weights,
+        resume_embeddings=resume_embeddings,
     )
 
 
@@ -140,17 +159,21 @@ def score_resumes(
 
     matches: List[ResumeMatch] = []
     for resume_id, tokens in corpus.resume_tokens.items():
-        resume_vector = corpus.resume_weights.get(resume_id, {})
-        score = _cosine_similarity(corpus.job_weights, resume_vector)
+        resume_vector = corpus.resume_embeddings.get(resume_id)
+        if resume_vector is None:
+            continue
+        score = _cosine_similarity_dense(corpus.job_embedding, resume_vector)
         if score < min_score:
             continue
 
         # Highlight keywords that carry the most weight for both the resume and job description.
         candidate_terms = []
+        job_term_counts = Counter(corpus.job_tokens)
+        resume_term_counts = Counter(tokens)
         for term in set(tokens):
-            if term not in corpus.job_weights:
+            if term not in job_term_counts:
                 continue
-            weight = resume_vector.get(term, 0.0) * corpus.job_weights.get(term, 0.0)
+            weight = job_term_counts[term] * resume_term_counts[term]
             if weight <= 0.0:
                 continue
             candidate_terms.append((term, weight))
@@ -172,11 +195,15 @@ def extract_keyword_insights(
 ) -> List[KeywordInsight]:
     """Return the most important job description keywords and their coverage."""
 
-    if not corpus.job_weights:
+    if not corpus.job_tokens:
         return []
 
+    job_term_counts = Counter(corpus.job_tokens)
+    total_terms = sum(job_term_counts.values()) or 1
     sorted_terms = sorted(
-        corpus.job_weights.items(), key=lambda item: item[1], reverse=True
+        ((term, count / total_terms) for term, count in job_term_counts.items()),
+        key=lambda item: item[1],
+        reverse=True,
     )
     total_resumes = len(corpus.resume_tokens)
 
@@ -201,11 +228,12 @@ def missing_keywords_for_resume(
 ) -> Tuple[str, ...]:
     """Identify the most important job keywords missing from a resume."""
 
-    if resume_id not in corpus.resume_tokens or not corpus.job_weights:
+    if resume_id not in corpus.resume_tokens or not corpus.job_tokens:
         return ()
 
+    job_term_counts = Counter(corpus.job_tokens)
     ordered_terms = [
-        term for term, _ in sorted(corpus.job_weights.items(), key=lambda item: item[1], reverse=True)
+        term for term, _ in sorted(job_term_counts.items(), key=lambda item: item[1], reverse=True)
     ]
     resume_terms = set(corpus.resume_tokens[resume_id])
     missing = [term for term in ordered_terms if term not in resume_terms][:top_n]

--- a/resume_screener/tests/test_matching.py
+++ b/resume_screener/tests/test_matching.py
@@ -1,6 +1,33 @@
 from __future__ import annotations
 
+import numpy as np
+import pytest
+
 from resume_screener import matching
+
+
+@pytest.fixture(autouse=True)
+def _fake_sentence_embeddings(monkeypatch):
+    def _embed(text: str) -> np.ndarray:
+        tokens = matching.preprocessing.tokenize(text)
+        vector = np.zeros(16, dtype=float)
+        for token in tokens:
+            index = sum(ord(char) for char in token) % vector.size
+            vector[index] += 1.0
+        norm = np.linalg.norm(vector)
+        if norm > 0.0:
+            vector /= norm
+        return vector
+
+    def _build_embeddings(job_description, resume_text_by_id, *, model_name=matching.DEFAULT_EMBEDDING_MODEL):
+        job_vector = _embed(job_description)
+        resume_vectors = {
+            resume_id: _embed(text)
+            for resume_id, text in resume_text_by_id.items()
+        }
+        return job_vector, resume_vectors
+
+    monkeypatch.setattr(matching, "build_sentence_embeddings", _build_embeddings)
 
 
 def _build_sample_corpus():
@@ -39,13 +66,13 @@ def test_score_resumes_filters_by_threshold():
     assert [match.resume_id for match in matches] == ["alice"]
 
 
-def test_prepare_corpus_returns_tokens_and_weights():
+def test_prepare_corpus_returns_tokens_and_embeddings():
     _, _, corpus = _build_sample_corpus()
 
     assert corpus.job_tokens
-    assert "python" in corpus.job_weights
+    assert corpus.job_embedding.size > 0
     assert "alice" in corpus.resume_tokens
-    assert corpus.resume_weights["alice"]
+    assert corpus.resume_embeddings["alice"].size > 0
 
 
 def test_extract_keyword_insights_reports_coverage():


### PR DESCRIPTION
## Summary
- add a sentence-transformers dependency so dense text embeddings are available
- swap the TF-IDF pipeline for SentenceTransformer embeddings and cosine scoring
- refresh the matching tests to exercise the embedding flow with lightweight stubs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da1d4b70288325bfb71c9e764d4164