### PR TITLE
Add job description file upload support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-﻿pdfminer.six>=20221105
+pdfminer.six>=20221105
+python-docx>=1.0
 scikit-learn>=1.3
 streamlit>=1.30


### PR DESCRIPTION
## Summary
- add support for uploading a job description as a PDF, DOCX, or TXT file in the Streamlit UI
- share PDF extraction logic between resume and job description handling and add validation feedback for unsupported files
- include python-docx dependency to enable Word document parsing

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dacec5eea08325a3f4980d0d5d8563